### PR TITLE
Display CreditCheckNotApproved error message

### DIFF
--- a/catalog/controller/payment/factoring.php
+++ b/catalog/controller/payment/factoring.php
@@ -214,6 +214,9 @@ class ControllerPaymentFactoring extends Controller
             if (preg_match('/\bInvalid parameter:msisdn\b/i', $result['description'])) {
                 $this->session->data['payex_error'] = $this->language->get('error_invalid_msisdn');
             }
+			else if (preg_match('/\bCreditCheckNotApproved\b/i', $result['errorCode'])) {
+				$this->session->data['payex_error'] = $this->language->get('error_creditCheckNotApproved');
+			}
 
             $this->response->redirect($this->url->link('payment/' . $this->_module_name . '/error', '', 'SSL'));
         }

--- a/catalog/language/english/payment/payex_error.php
+++ b/catalog/language/english/payment/payex_error.php
@@ -18,4 +18,4 @@ $_['error_transaction_authorized_cant_capture'] = 'Transaction authorized. But c
 $_['error_payex'] = 'PayEx error: %s';
 $_['error_invalid_order_reference'] = 'Invalid order reference';
 $_['error_invalid_bank'] = 'Invalid bank';
-$_['error_creditCheckNotApproved'] = 'Credit check was declined by PayEx.';
+$_['error_creditCheckNotApproved'] = 'Credit check was declined, please try another payment option.';

--- a/catalog/language/english/payment/payex_error.php
+++ b/catalog/language/english/payment/payex_error.php
@@ -18,3 +18,4 @@ $_['error_transaction_authorized_cant_capture'] = 'Transaction authorized. But c
 $_['error_payex'] = 'PayEx error: %s';
 $_['error_invalid_order_reference'] = 'Invalid order reference';
 $_['error_invalid_bank'] = 'Invalid bank';
+$_['error_creditCheckNotApproved'] = 'Credit check was declined by PayEx.';

--- a/catalog/language/swedish/payment/payex_error.php
+++ b/catalog/language/swedish/payment/payex_error.php
@@ -18,4 +18,4 @@ $_['error_transaction_authorized_cant_capture'] = 'Transaktionen godkändes. Men
 $_['error_payex'] = 'PayEx error: %s';
 $_['error_invalid_order_reference'] = 'Ogiltig order reference';
 $_['error_invalid_bank'] = 'Ogiltig bank';
-$_['error_creditCheckNotApproved'] = 'Kreditkontrollen avslogs av PayEx.';
+$_['error_creditCheckNotApproved'] = 'Tyvärr kan kredit ej medges, vänligen prova annat betalsätt.';

--- a/catalog/language/swedish/payment/payex_error.php
+++ b/catalog/language/swedish/payment/payex_error.php
@@ -18,3 +18,4 @@ $_['error_transaction_authorized_cant_capture'] = 'Transaktionen godkändes. Men
 $_['error_payex'] = 'PayEx error: %s';
 $_['error_invalid_order_reference'] = 'Ogiltig order reference';
 $_['error_invalid_bank'] = 'Ogiltig bank';
+$_['error_creditCheckNotApproved'] = 'Kreditkontrollen avslogs av PayEx.';


### PR DESCRIPTION
This small change implements a check for "CreditCheckDeclined" in PayEx response -> errorCode. It also adds a new error message to the language specific payex_error.php files to facilitate customization of the error message by merchant. Custom text for declined credit check is a common request from merchant.
